### PR TITLE
Removed 'drop materialized view'. Unnecessary

### DIFF
--- a/src/timetell/datapunt.sql
+++ b/src/timetell/datapunt.sql
@@ -917,8 +917,6 @@ ORDER BY
 
 -- View: "{schemaname}".v_timetell_projectenoverzicht_7
 
-DROP MATERIALIZED VIEW "{schemaname}".v_timetell_projectenoverzicht_7;
-
 CREATE MATERIALIZED VIEW "{schemaname}".v_timetell_projectenoverzicht_7
 AS
 WITH w_project_adviseur AS (


### PR DESCRIPTION
We always import into an empty database, therefore
this statement always fails (and is unnecessary anyway).