### PR TITLE
toevoegen-veld-status_project-aan-projectenoverzicht_7-vervolg

### DIFF
--- a/src/timetell/datapunt.sql
+++ b/src/timetell/datapunt.sql
@@ -828,7 +828,8 @@ SELECT
     project.code,
     project.calc_hours,
     project.calc_costs,
-    project."Project Nummer"
+    project."Project Nummer",
+    project.status_project
    FROM ( SELECT 0 AS prj_niv,
             a0.name AS prj_niv_name,
             a0.name AS prj_niv0_name,


### PR DESCRIPTION
1 (select)regel vergeten toe te voegen bij de vorige pull request, waardoor het veld status_project nog niet mee kwam in de view. 